### PR TITLE
feat: add extra subscription message on reconnect 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1.35", features = ["rt-multi-thread", "sync"] }
 tokio-stream = "0.1"
 tokio-retry = "0.3"
 tracing = "0.1"
+thiserror = "1"
 
 # optional dependencies
 subxt = { version = "0.33", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ type SubscriptionResult = Result<Box<RawValue>, DisconnectWillReconnect>;
 /// An opaque error that indicates the subscription
 /// was disconnnected and will automatically reconnect.
 #[derive(Debug, Clone, thiserror::Error)]
-#[error("The client was disconnected and reconnecting.")]
+#[error("The client was disconnected and reconnect initiated.")]
 pub struct DisconnectWillReconnect;
 
 /// Serialized JSON-RPC params.


### PR DESCRIPTION
The error kind `DisconnectWillReconnect` has been added as explicit
error type to indicate when a re-connection occurs.

Then additional APIs has been added to return a future once
a re-connection occurs.