### PR TITLE
add support for wasm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,6 @@ jobs:
         uses: actions-rs/clippy-check@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
 
   check-docs:
     name: Check rustdoc
@@ -89,8 +88,14 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2.7.3
 
-      - name: Cargo check all targets and features
-        run: cargo hack check --workspace --each-feature --all-targets
+      - name: Cargo check all targets and features, except wasm
+        run: |
+          cargo check
+          cargo hack check --workspace --each-feature --exclude-no-default-features --exclude-all-features --exclude-features=web  --all-targets
+
+      - name: Check wasm
+        run: |
+          cargo check --no-default-features --features=web --target wasm32-unknown-unknown
 
       - name: Check unused dependencies
         run: cargo machete

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           override: true
 
       - name: Check rustdoc
-        run: RUSTDOCFLAGS="--cfg docsrs --deny rustdoc::broken_intra_doc_links" cargo doc --verbose --workspace --no-deps --document-private-items --all-features
+        run: RUSTDOCFLAGS="--cfg docsrs --deny rustdoc::broken_intra_doc_links" cargo doc --verbose --workspace --no-deps --document-private-items
 
   check-code:
     name: Check
@@ -95,6 +95,7 @@ jobs:
 
       - name: Check wasm
         run: |
+          rustup target add wasm32-unknown-unknown
           cargo check --no-default-features --features=web --target wasm32-unknown-unknown
 
       - name: Check unused dependencies

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,24 +11,36 @@ documentation = "https://docs.rs/reconnecting-jsonrpsee-ws-client"
 keywords = ["jsonrpc", "json", "websocket"]
 readme = "README.md"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-futures = "0.3"
-jsonrpsee = { version = "0.22", features = ["ws-client"] }
-serde_json = { version = "1", features = ["raw_value"] }
-tokio = { version = "1.35", features = ["rt-multi-thread", "sync"] }
-tokio-stream = "0.1"
-tokio-retry = "0.3"
-tracing = "0.1"
+futures = { version = "0.3", default-features = false }
+jsonrpsee = { version = "0.22", default-features = false }
+serde_json = { version = "1", features = ["raw_value"], default-features = false }
+tokio = { version = "1.35", features = ["sync"], default-features = false }
+tokio-stream = { version = "0.1", default-features = false }
+tokio-retry = { git = "https://github.com/polytope-labs/rust-tokio-retry", branch = "master" }
+tracing = { version = "0.1", default-features = false }
 thiserror = "1"
+wasm-bindgen-futures = { version = "0.4.41", optional = true }
 
 # optional dependencies
 subxt = { version = "0.34", optional = true }
 
 [features]
-default = []
+default = ["std"]
+std = [
+    "futures/std",
+    "serde_json/std",
+    "tokio/rt-multi-thread",
+    "tracing/std",
+    "jsonrpsee/ws-client",
+]
 subxt = ["dep:subxt"]
+web = [
+    "jsonrpsee/jsonrpsee-types",
+    "jsonrpsee/async-wasm-client",
+    "jsonrpsee/client-web-transport",
+    "wasm-bindgen-futures",
+]
 
 [dev-dependencies]
 jsonrpsee = { version = "0.22", features = ["server"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,22 +17,24 @@ jsonrpsee = { version = "0.22", default-features = false }
 serde_json = { version = "1", features = ["raw_value"], default-features = false }
 tokio = { version = "1.35", features = ["sync"], default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
-tokio-retry = { git = "https://github.com/polytope-labs/rust-tokio-retry", branch = "master" }
 tracing = { version = "0.1", default-features = false }
 thiserror = "1"
 wasm-bindgen-futures = { version = "0.4.41", optional = true }
+wasm-tokio-retry = { package = "tokio-retry", git = "https://github.com/polytope-labs/rust-tokio-retry", branch = "master", optional = true }
+native-tokio-retry = { package = "tokio-retry", version = "0.3.0", optional = true }
 
 # optional dependencies
 subxt = { version = "0.34", optional = true }
 
 [features]
-default = ["std"]
-std = [
+default = []
+native = [
     "futures/std",
     "serde_json/std",
     "tokio/rt-multi-thread",
     "tracing/std",
     "jsonrpsee/ws-client",
+    "native-tokio-retry",
 ]
 subxt = ["dep:subxt"]
 web = [
@@ -40,6 +42,7 @@ web = [
     "jsonrpsee/async-wasm-client",
     "jsonrpsee/client-web-transport",
     "wasm-bindgen-futures",
+    "wasm-tokio-retry"
 ]
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ native = [
     "jsonrpsee/ws-client",
     "again/default",
 ]
-subxt = ["dep:subxt"]
+subxt = ["dep:subxt", "native"]
 web = [
     "jsonrpsee/jsonrpsee-types",
     "jsonrpsee/async-wasm-client",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,22 +19,22 @@ tokio = { version = "1.35", features = ["sync"], default-features = false }
 tokio-stream = { version = "0.1", default-features = false }
 tracing = { version = "0.1", default-features = false }
 thiserror = "1"
-wasm-bindgen-futures = { version = "0.4.41", optional = true }
-wasm-tokio-retry = { package = "tokio-retry", git = "https://github.com/polytope-labs/rust-tokio-retry", branch = "master", optional = true }
-native-tokio-retry = { package = "tokio-retry", version = "0.3.0", optional = true }
+getrandom = { version = "0.2.12", default-features = false }
+again = { git = "https://github.com/softprops/again", branch = "develop", default-features = false }
 
 # optional dependencies
 subxt = { version = "0.34", optional = true }
+wasm-bindgen-futures = { version = "0.4.41", optional = true }
 
 [features]
-default = []
+default = ["native"]
 native = [
     "futures/std",
     "serde_json/std",
     "tokio/rt-multi-thread",
     "tracing/std",
     "jsonrpsee/ws-client",
-    "native-tokio-retry",
+    "again/default",
 ]
 subxt = ["dep:subxt"]
 web = [
@@ -42,7 +42,8 @@ web = [
     "jsonrpsee/async-wasm-client",
     "jsonrpsee/client-web-transport",
     "wasm-bindgen-futures",
-    "wasm-tokio-retry"
+    "again/wasm-bindgen",
+    "getrandom/js",
 ]
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -860,7 +860,7 @@ mod tests {
         let (_handle, addr) = run_server().await.unwrap();
 
         let client = Client::builder()
-            .retry_policy(ExponentialBackoff::from_millis(50))
+            .retry_policy(RetryPolicy::exponential(Duration::from_millis(50)))
             .build(addr)
             .await
             .unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -784,7 +784,7 @@ async fn reconnect(params: ReconnectParams<'_>) -> Result<Arc<WsClient>, RpcErro
         };
     }
 
-    tracing::debug!(target: LOG_TARGET, "Connection was closed: `{}`", display_close_reason(&close_reason));
+    tracing::debug!(target: LOG_TARGET, "Connection to {url} was closed: `{}`", display_close_reason(&close_reason));
 
     reconnect.reconnect();
     let client = retry_policy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,11 +82,9 @@ use utils::{reconnect_channel, MaybePendingFutures, ReconnectRx, ReconnectTx};
 
 // re-exports
 pub use again::RetryPolicy;
-pub use jsonrpsee::{
-    core::client::{async_client::PingConfig, error::Error as RpcError},
-    rpc_params,
-    types::SubscriptionId,
-};
+#[cfg(all(feature = "native", not(feature = "web")))]
+pub use jsonrpsee::core::client::async_client::PingConfig;
+pub use jsonrpsee::{core::client::error::Error as RpcError, rpc_params, types::SubscriptionId};
 
 const LOG_TARGET: &str = "reconnecting_jsonrpsee_ws_client";
 
@@ -178,6 +176,7 @@ pub struct ClientBuilder {
     max_request_size: u32,
     max_response_size: u32,
     retry_policy: RetryPolicy,
+    #[cfg(all(feature = "native", not(feature = "web")))]
     ping_config: Option<PingConfig>,
     #[cfg(all(feature = "native", not(feature = "web")))]
     // web doesn't support custom headers
@@ -197,6 +196,7 @@ impl Default for ClientBuilder {
             max_request_size: 10 * 1024 * 1024,
             max_response_size: 10 * 1024 * 1024,
             retry_policy: RetryPolicy::exponential(Duration::from_millis(10)),
+            #[cfg(all(feature = "native", not(feature = "web")))]
             ping_config: Some(PingConfig::new()),
             #[cfg(all(feature = "native", not(feature = "web")))]
             headers: HeaderMap::new(),
@@ -298,6 +298,7 @@ impl ClientBuilder {
         self
     }
 
+    #[cfg(all(feature = "native", not(feature = "web")))]
     /// Configure the WebSocket ping/pong interval.
     ///
     /// Default: 30 seconds.
@@ -306,6 +307,7 @@ impl ClientBuilder {
         self
     }
 
+    #[cfg(all(feature = "native", not(feature = "web")))]
     /// Disable WebSocket ping/pongs.
     ///
     /// Default: 30 seconds.

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -2,26 +2,14 @@ use crate::{ClientBuilder, RpcError};
 use jsonrpsee::core::client::Client;
 use std::sync::Arc;
 
-#[cfg(feature = "native")]
+#[cfg(all(feature = "native", not(feature = "web")))]
 pub use tokio::spawn;
 
-#[cfg(feature = "web")]
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
 pub use wasm_bindgen_futures::spawn_local as spawn;
 
-#[cfg(feature = "native")]
-pub mod retry {
-    pub use native_tokio_retry::strategy::*;
-    pub use native_tokio_retry::Retry;
-}
-
-#[cfg(feature = "web")]
-pub mod retry {
-    pub use wasm_tokio_retry::strategy::*;
-    pub use wasm_tokio_retry::Retry;
-}
-
-#[cfg(feature = "native")]
-pub async fn ws_client<P>(url: &str, builder: &ClientBuilder<P>) -> Result<Arc<Client>, RpcError> {
+#[cfg(all(feature = "native", not(feature = "web")))]
+pub async fn ws_client(url: &str, builder: &ClientBuilder) -> Result<Arc<Client>, RpcError> {
     use jsonrpsee::ws_client::WsClientBuilder;
 
     let ClientBuilder {
@@ -60,8 +48,8 @@ pub async fn ws_client<P>(url: &str, builder: &ClientBuilder<P>) -> Result<Arc<C
     Ok(Arc::new(client))
 }
 
-#[cfg(feature = "web")]
-pub async fn ws_client<P>(url: &str, builder: &ClientBuilder<P>) -> Result<Arc<Client>, RpcError> {
+#[cfg(all(feature = "web", target_arch = "wasm32"))]
+pub async fn ws_client(url: &str, builder: &ClientBuilder) -> Result<Arc<Client>, RpcError> {
     use jsonrpsee::client_transport::web;
     use jsonrpsee::core::client::ClientBuilder as RpseeClientBuilder;
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 #[cfg(all(feature = "native", not(feature = "web")))]
 pub use tokio::spawn;
 
-#[cfg(all(feature = "web", target_arch = "wasm32"))]
+#[cfg(all(feature = "web", target_arch = "wasm32", not(feature = "native")))]
 pub use wasm_bindgen_futures::spawn_local as spawn;
 
 #[cfg(all(feature = "native", not(feature = "web")))]
@@ -48,7 +48,7 @@ pub async fn ws_client(url: &str, builder: &ClientBuilder) -> Result<Arc<Client>
     Ok(Arc::new(client))
 }
 
-#[cfg(all(feature = "web", target_arch = "wasm32"))]
+#[cfg(all(feature = "web", target_arch = "wasm32", not(feature = "native")))]
 pub async fn ws_client(url: &str, builder: &ClientBuilder) -> Result<Arc<Client>, RpcError> {
     use jsonrpsee::client_transport::web;
     use jsonrpsee::core::client::ClientBuilder as RpseeClientBuilder;

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -54,7 +54,6 @@ pub async fn ws_client(url: &str, builder: &ClientBuilder) -> Result<Arc<Client>
     use jsonrpsee::core::client::ClientBuilder as RpseeClientBuilder;
 
     let ClientBuilder {
-        ping_config,
         id_kind,
         max_concurrent_requests,
         max_log_len,
@@ -66,17 +65,13 @@ pub async fn ws_client(url: &str, builder: &ClientBuilder) -> Result<Arc<Client>
         .await
         .map_err(|e| RpcError::Transport(e.into()))?;
 
-    let mut ws_client_builder = RpseeClientBuilder::new()
+    let ws_client_builder = RpseeClientBuilder::new()
         .max_buffer_capacity_per_subscription(tokio::sync::Semaphore::MAX_PERMITS)
         .max_concurrent_requests(*max_concurrent_requests as usize)
         .set_max_logging_length(*max_log_len)
         .set_tcp_no_delay(true)
         .request_timeout(*request_timeout)
         .id_format(*id_kind);
-
-    if let Some(ping) = ping_config {
-        ws_client_builder = ws_client_builder.enable_ws_ping(*ping);
-    }
 
     let client = ws_client_builder.build_with_wasm(tx, rx);
 

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -1,0 +1,82 @@
+use std::sync::Arc;
+use jsonrpsee::core::client::Client;
+
+#[cfg(not(feature = "web"))]
+pub use tokio::spawn;
+
+#[cfg(feature = "web")]
+pub use wasm_bindgen_futures::spawn_local as spawn;
+use crate::{ClientBuilder, RpcError};
+
+#[cfg(not(feature = "web"))]
+pub async fn ws_client<P>(url: &str, builder: &ClientBuilder<P>) -> Result<Arc<Client>, RpcError> {
+    use jsonrpsee::ws_client::WsClientBuilder;
+
+    let ClientBuilder {
+        max_request_size,
+        max_response_size,
+        ping_config,
+        headers,
+        max_redirections,
+        id_kind,
+        max_concurrent_requests,
+        max_log_len,
+        request_timeout,
+        connection_timeout,
+        ..
+    } = builder;
+
+    let mut ws_client_builder = WsClientBuilder::new()
+        .max_request_size(*max_request_size)
+        .max_response_size(*max_response_size)
+        .set_headers(headers.clone())
+        .max_redirections(*max_redirections as usize)
+        .max_buffer_capacity_per_subscription(tokio::sync::Semaphore::MAX_PERMITS)
+        .max_concurrent_requests(*max_concurrent_requests as usize)
+        .set_max_logging_length(*max_log_len)
+        .set_tcp_no_delay(true)
+        .request_timeout(*request_timeout)
+        .connection_timeout(*connection_timeout)
+        .id_format(*id_kind);
+
+    if let Some(ping) = ping_config {
+        ws_client_builder = ws_client_builder.enable_ws_ping(*ping);
+    }
+
+    let client = ws_client_builder.build(url).await?;
+
+    Ok(Arc::new(client))
+}
+
+#[cfg(feature = "web")]
+pub async fn ws_client<P>(url: &str, builder: &ClientBuilder<P>) -> Result<Arc<Client>, RpcError> {
+    use jsonrpsee::client_transport::web;
+    use jsonrpsee::core::client::ClientBuilder as RpseeClientBuilder;
+
+    let ClientBuilder {
+        ping_config,
+        id_kind,
+        max_concurrent_requests,
+        max_log_len,
+        request_timeout,
+        ..
+    } = builder;
+
+    let (tx, rx) = web::connect(url).await.map_err(|e| RpcError::Transport(e.into()))?;
+
+    let mut ws_client_builder = RpseeClientBuilder::new()
+        .max_buffer_capacity_per_subscription(tokio::sync::Semaphore::MAX_PERMITS)
+        .max_concurrent_requests(*max_concurrent_requests as usize)
+        .set_max_logging_length(*max_log_len)
+        .set_tcp_no_delay(true)
+        .request_timeout(*request_timeout)
+        .id_format(*id_kind);
+
+    if let Some(ping) = ping_config {
+        ws_client_builder = ws_client_builder.enable_ws_ping(*ping);
+    }
+
+    let client = ws_client_builder.build_with_wasm(tx, rx);
+
+    Ok(Arc::new(client))
+}


### PR DESCRIPTION
Basically moved platform specific stuff to a new module. Switched to [softprops/again](https://github.com/softprops/again) which supports `wasm-bindgen`. closes #22